### PR TITLE
package.json fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "express": "^4.14.0",
     "file-loader": "^0.9.0",
     "foundation-sites": "^6.2.3",
-    "grommet": "https://github.com/ryanccollins/grommet/tarball/stable",
+    "grommet-udacity": "https://github.com/ryanccollins/grommet/tarball/stable",
     "grunt": "^0.4.5",
     "history": "^1.14.0",
     "html-webpack-plugin": "^2.7.1",


### PR DESCRIPTION
Hi Ryan,

I met a problem in installing npm packages, console showed that npm could not find grommet but find grommet-udacity instead, I guess your grommet package 's npm install command is still "npm install grommet-udacity",
so I changed "grommet": "https://github.com/ryanccollins/grommet/tarball/stable"  to  "grommet-udacity": "https://github.com/ryanccollins/grommet/tarball/stable" in package.json.  